### PR TITLE
[node] The error callback should be triggered if the server returns a non-200 HTTP status code

### DIFF
--- a/node/rdio.js
+++ b/node/rdio.js
@@ -103,8 +103,11 @@ Rdio.prototype._signedPost = function signedPost(urlString, params, callback) {
             
             try {
                 data = JSON.parse(body);
-            } catch(e) {}
-            
+            } catch(e) {
+                data.status = 'error';
+                data.message = body;
+            }
+
             if (data.status === 'error') {
                 callback(data.message);
             } else {


### PR DESCRIPTION
The `error` event of http.request(…) doesn't get called when the HTTP status code is non-200; it gets triggered for more catastrophic network failures.

This pull request introduces some rudimentary HTTP status code checking, and fires the right handler.
