### PR TITLE
Make sure signedPost sends error when appropriate.

### DIFF
--- a/node/rdio.js
+++ b/node/rdio.js
@@ -101,11 +101,7 @@ Rdio.prototype._signedPost = function signedPost(urlString, params, callback) {
         res.on("end", function () {
             var statusCode = res.statusCode;
             if (statusCode != 200) {
-                var err = {
-                  statusCode: statusCode,
-                  body: body
-                };
-                callback(err);
+                callback(res);
             } else {
                 callback(null, body);
             }


### PR DESCRIPTION
@steveluscher, I think this is a better way to handle the issue you opened, as it allows the actual error message provided by the server to propagate, rather than a generic message that just repeats the status code.

What do you think?
