### PR TITLE
Fixed parse issue in rdio.js

### DIFF
--- a/node/rdio.js
+++ b/node/rdio.js
@@ -104,10 +104,14 @@ Rdio.prototype._signedPost = function signedPost(urlString, params, callback) {
             try {
                 data = JSON.parse(body);
             } catch(e) {
-                data.status = 'error';
-                data.message = body;
-            }
+                data = qs.parse(body);
 
+                if(!data.oauth_token) {
+                    data.status = 'error';
+                    data.message = body;
+                }
+            }
+            
             if (data.status === 'error') {
                 callback(data.message);
             } else {


### PR DESCRIPTION
The rdio oauth endpoints:
- [api.rdio.com/oauth/request_token](http://api.rdio.com/oauth/request_token) and
- [api.rdio.com/oauth/access_token](http://api.rdio.com/oauth/access_token)
  actually return a url-encoded response,
  which results in JSON.parse throwing an error.

Added a querystring parser in the `try..catch` block, to fix that.
